### PR TITLE
Adding overrideable default headers

### DIFF
--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -9,6 +9,11 @@ end
 
 $cache = {}
 
+def default_headers_or_hash
+  return {} unless defined? default_headers
+  default_headers
+end
+
 Given(/^I send and accept JSON$/) do
   steps %Q{
     Given I send "application/json" and accept JSON
@@ -19,7 +24,7 @@ Given(/^I send "(.*?)" and accept JSON$/) do |content_type|
   @headers = {
       :Accept => 'application/json',
       :'Content-Type' => %/#{content_type}/
-  }
+  }.merge(default_headers_or_hash)
 end
 
 Given(/^I add Headers:$/) do |params|
@@ -105,7 +110,7 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
     next
   end
 
-  @headers = {} if @headers.nil?
+  @headers = default_headers_or_hash if @headers.nil?
   begin
     case method
       when 'GET'
@@ -123,7 +128,7 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
     response = e.response
   end
   @response = CucumberApi::Response.create response
-  @headers = nil
+  @headers = default_headers_or_hash
   @body = nil
   $cache[%/#{request_url}/] = @response if 'GET' == %/#{method}/
 end

--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -18,10 +18,10 @@ Given(/^I send and accept JSON$/) do
 end
 
 Given(/^I send "(.*?)" and accept JSON$/) do |content_type|
-  @headers = {
+  @headers = $default_headers.merge({
       :Accept => 'application/json',
       :'Content-Type' => %/#{content_type}/
-  }.merge($default_headers)
+  })
 end
 
 Given(/^I add Headers:$/) do |params|

--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -9,10 +9,7 @@ end
 
 $cache = {}
 
-def default_headers_or_hash
-  return {} unless defined? default_headers
-  default_headers
-end
+$default_headers ||= {}
 
 Given(/^I send and accept JSON$/) do
   steps %Q{
@@ -24,7 +21,7 @@ Given(/^I send "(.*?)" and accept JSON$/) do |content_type|
   @headers = {
       :Accept => 'application/json',
       :'Content-Type' => %/#{content_type}/
-  }.merge(default_headers_or_hash)
+  }.merge($default_headers)
 end
 
 Given(/^I add Headers:$/) do |params|
@@ -110,7 +107,7 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
     next
   end
 
-  @headers = default_headers_or_hash if @headers.nil?
+  @headers = $default_headers if @headers.nil?
   begin
     case method
       when 'GET'
@@ -128,7 +125,7 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
     response = e.response
   end
   @response = CucumberApi::Response.create response
-  @headers = default_headers_or_hash
+  @headers = $default_headers
   @body = nil
   $cache[%/#{request_url}/] = @response if 'GET' == %/#{method}/
 end


### PR DESCRIPTION
Instead of being assigned to `nil`, `@headers` are now assigned to a `default_headers_or_hash` method that checks to see if a user provided `default_headers` method has been defined and returns that, or returns empty hash.