### PR TITLE
Bump dependencies / Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,14 @@
 language: ruby
+sudo: false
+
+rvm:
+    - 2.3
+    - 2.4
+    - ruby-head
+
+matrix:
+    allow_failures:
+        - ruby-head
+
 script: "cucumber -p verbose"
+

--- a/cucumber-api.gemspec
+++ b/cucumber-api.gemspec
@@ -13,14 +13,12 @@ Gem::Specification.new do |s|
   s.description = %q{cucumber-api allows API JSON response validation and verification in BDD style.}
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.3.0'
   s.license     = 'Apache-2.0'
 
-  # lock addressable down to the last one that works on MRI 1.9.3
-  s.add_dependency('addressable', '2.4')
-
-  s.add_dependency('cucumber', '~> 2.0')
-  s.add_dependency('jsonpath', '~> 0.5')
-  s.add_dependency('rest-client', '~> 1.8')
-  s.add_dependency('json-schema', '~> 2.5')
+  s.add_dependency('addressable', '2.5')
+  s.add_dependency('cucumber', '~> 3.1.0')
+  s.add_dependency('jsonpath', '~> 0.8')
+  s.add_dependency('rest-client', '~> 2.0.2')
+  s.add_dependency('json-schema', '~> 2.8.0')
 end

--- a/lib/cucumber-api/response.rb
+++ b/lib/cucumber-api/response.rb
@@ -6,9 +6,6 @@ module CucumberApi
 
   # Extension of {RestClient::Response} with support for JSON path traversal and validation
   module Response
-
-    include RestClient::Response
-
     # Create a Response with JSON path support
     # @param response [RestClient::Response] original response
     # @return [Response] self
@@ -115,5 +112,6 @@ module CucumberApi
         ''
       end
     end
+    RestClient::Response.send(:include, self)
   end
 end

--- a/lib/cucumber-api/version.rb
+++ b/lib/cucumber-api/version.rb
@@ -1,3 +1,3 @@
 module CucumberApi
-  VERSION = "0.4"
+  VERSION = "0.5"
 end


### PR DESCRIPTION
This updates the dependencies for cucumber-api, mainly to work around rest-client issues with newer rubies. Ruby 1.9.3 has been EOL for quite some time, so I've bumped the minimum ruby to 2.3 (since 2.2 will be EOL'd in March.)