### PR TITLE
Add support for response header parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ This will be handy when one needs to make a sequence of calls to authenticate/au
 **Assert steps**
 
 Verify:
+
 * HTTP response status code
 * JSON response against a JSON schema conforming to [JSON Schema Draft 4](http://tools.ietf.org/html/draft-zyp-json-schema-04)
 * Adhoc JSON response key-value type pair, where key is a [JSON path](http://goessner.net/articles/JsonPath/)
+* Response header presence and header values
 
 ```gherkin
 Then the response status should be "(\d+)"
@@ -151,6 +153,8 @@ Then the JSON response root should be (object|array)
 Then the JSON response should have key "([^\"]*)"
 Then the JSON response should have (required|optional) key "(.*?)" of type (numeric|string|boolean|numeric_string|object|array|any)( or null)
 Then the JSON response should have (required|optional) key "(.*?)" of type (numeric|string|boolean|numeric_string|object|array|any)( or null) and value "(.*?)"
+Then the response headers should contain "([^"]*)"
+Then the response headers should contain "([^"]*)" with value "([^"]*)"
 ```
 
 Example:
@@ -162,6 +166,8 @@ Then the JSON response root should be array
 Then the JSON response should have key "id"
 Then the JSON response should have optional key "format" of type string or null
 Then the JSON response should have required key "status" of type string and value "foobar"
+Then the response headers should contain "X-API-KEY"
+Then the response headers should contain "Transfer-Encoding" with value "chunked"
 ```
 
 Also checkout [sample](/features/sample.feature) for real examples. Run sample with the following command:

--- a/features/sample.feature
+++ b/features/sample.feature
@@ -46,3 +46,7 @@ Feature: Hacker News REST API validation
     And  the JSON response should have "body" of type string and value "bar"
     And  the JSON response should have "userId" of type numeric and value "1"
 
+ Scenario: Demonstrate header parsing
+   When I send a GET request to "http://jsonplaceholder.typicode.com/posts"
+   Then the response headers should contain "Content-Encoding"
+   And  the response headers should contain "Content-Type" with value "application/json; charset=utf-8"

--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -179,3 +179,20 @@ Then(/^the JSON response should have "([^"]*)" of type \
 (numeric|string|boolean|numeric_string) and value "([^"]*)"$/) do |json_path, type, value|
   @response.get_as_type_and_check_value json_path, type, resolve(value)
 end
+
+Then(/^the response headers should contain "([^"]*)"$/) do |name|
+    header_symbol = name.gsub(/[\s-]+/, '_').downcase.to_sym
+
+    raise %(Header "#{name}" not found) unless @response.headers.key?(header_symbol)
+end
+
+Then(/^the response headers should contain "([^"]*)" with value "([^"]*)"$/) do |name, expected_value|
+    steps %(
+        Then the response headers should contain "#{name}"
+    )
+    header_symbol = name.gsub(/[\s-]+/, '_').downcase.to_sym
+
+    actual_value = @response.headers[header_symbol]
+
+    raise %(For header "#{name}" expected "#{expected_value}" but got "#{actual_value}") if actual_value != expected_value
+end


### PR DESCRIPTION
Add the ability to assert things like this:

```gherkin
Then the response headers should contain "X-API-KEY"
Then the response headers should contain "Transfer-Encoding" with value "chunked"
```

Note that the following line appears in both step declarations. I'd like to not do that, but am unsure of the best way to refactor this (I'm not a ruby developer). Open to suggestions.

```ruby
header_symbol = name.gsub(/[\s-]+/, '_').downcase.to_sym
```