### PR TITLE
Delete request with body

### DIFF
--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -124,7 +124,7 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
         if @body
           response = RestClient::Request.execute(
             method:  :delete,
-            url:     url,
+            url:     request_url,
             payload: @body,
             headers: @headers
           )

--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -121,7 +121,16 @@ When(/^I send a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, ur
       when 'PUT'
         response = RestClient.put request_url, @body, @headers
       else
-        response = RestClient.delete request_url, @headers
+        if @body
+          response = RestClient::Request.execute(
+            method:  :delete,
+            url:     url,
+            payload: @body,
+            headers: @headers
+          )
+        else
+          response = RestClient.delete request_url, @headers
+        end
     end
   rescue RestClient::Exception => e
     response = e.response


### PR DESCRIPTION
Developers in my company created a Delete endpoint that includes a request body. After some digging I learned that it was a rest-client advanced option to send a Delete with a body. So I'm proposing adding this IF or something like it to cover the edge case of a Delete with a body.