### PR TITLE
Raise error when schema is expected but missing

### DIFF
--- a/lib/cucumber-api/steps.rb
+++ b/lib/cucumber-api/steps.rb
@@ -146,8 +146,7 @@ Then(/^the JSON response should follow "(.*?)"$/) do |schema|
                                               $!.fragments, $!.failed_attribute, $!.schema)
     end
   else
-    puts %/WARNING: missing schema '#{file_path}'/
-    pending
+    raise %/Schema not found: '#{file_path}'/
   end
 end
 


### PR DESCRIPTION
Currently, verifying json response against a missing schema is not considered a failure and an error message is printed into the console.

This PR will raise an error and handle the failure similar to when attempting to set request body from a missing file. https://github.com/hidroh/cucumber-api/blob/8d101d166b5eb0dd2f9f6eee5019e062bc3d4f11/lib/cucumber-api/steps.rb#L89